### PR TITLE
Feat/handling retries on sidekiq & set admin user before migrations and rollbacks

### DIFF
--- a/lib/pg_rls/database/tasks/admin_database.rake
+++ b/lib/pg_rls/database/tasks/admin_database.rake
@@ -32,6 +32,16 @@ namespace :db do
     Rake::Task['db:abort_if_pending_migrations:original'].invoke
   end
 
+  override_task :migrate do
+    PgRls.instance_variable_set(:@as_db_admin, true)
+    Rake::Task['db:migrate:original'].invoke
+  end
+
+  override_task :rollback do
+    PgRls.instance_variable_set(:@as_db_admin, true)
+    Rake::Task['db:rollback:original'].invoke
+  end
+
   namespace :test do
     override_task grant_usage: :load_config do
       PgRls.instance_variable_set(:@as_db_admin, true)

--- a/lib/pg_rls/database/tasks/admin_database.rake
+++ b/lib/pg_rls/database/tasks/admin_database.rake
@@ -22,24 +22,13 @@ end
 namespace :db do
   include PgRls::Schema::UpStatements
 
+  override_task :load_config do
+    PgRls.instance_variable_set(:@as_db_admin, true)
+    Rake::Task['db:load_config:original'].invoke
+  end
+
   override_task grant_usage: :load_config do
-    PgRls.instance_variable_set(:@as_db_admin, true)
     create_rls_user
-  end
-
-  override_task abort_if_pending_migrations: :load_config do
-    PgRls.instance_variable_set(:@as_db_admin, true)
-    Rake::Task['db:abort_if_pending_migrations:original'].invoke
-  end
-
-  override_task :migrate do
-    PgRls.instance_variable_set(:@as_db_admin, true)
-    Rake::Task['db:migrate:original'].invoke
-  end
-
-  override_task :rollback do
-    PgRls.instance_variable_set(:@as_db_admin, true)
-    Rake::Task['db:rollback:original'].invoke
   end
 
   namespace :test do

--- a/lib/pg_rls/middleware/sidekiq/client.rb
+++ b/lib/pg_rls/middleware/sidekiq/client.rb
@@ -12,12 +12,9 @@ module PgRls
         end
 
         def load_tenant_attribute!(msg)
-          if PgRls.admin_connection?
-            msg['admin'] = true
-          else
-            tenant = PgRls::Tenant.fetch!
-            msg['pg_rls'] = tenant.id
-          end
+          return msg['admin'] = true if PgRls.admin_connection?
+
+          msg['pg_rls'] ||= PgRls::Tenant.fetch&.id
         end
       end
     end

--- a/spec/middleware/sidekiq/client_spec.rb
+++ b/spec/middleware/sidekiq/client_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require 'pg_rls/middleware/sidekiq/client'
+require 'sidekiq/testing'
+
+# Define the dummy workers
+class DummyAdminWorker
+  include Sidekiq::Worker
+
+  def perform(*_args)
+    raise 'Not an admin connection' unless PgRls.admin_connection?
+
+    'Admin task'
+  end
+end
+
+class DummyTenantWorker
+  include Sidekiq::Worker
+
+  def perform(*_args)
+    raise 'Not a tenant connection' if PgRls.admin_connection?
+
+    PgRls::Tenant.fetch
+  end
+end
+
+class DummyFailingWorker
+  include Sidekiq::Worker
+
+  def perform(*_args)
+    raise 'Failed job'
+  end
+end
+
+RSpec.describe PgRls::Middleware::Sidekiq::Client do
+  before(:all) do
+    Sidekiq.configure_client do |config|
+      config.logger.level = Logger::WARN
+      config.client_middleware do |chain|
+        chain.add described_class
+      end
+    end
+  end
+
+  describe 'middleware behavior' do
+    context 'when admin connection is true' do
+      before do
+        allow(PgRls).to receive(:admin_connection?).and_return(true)
+      end
+
+      it 'sets admin attribute to true for the job' do
+        Sidekiq::Testing.inline! do
+          DummyAdminWorker.perform_async
+        end
+      end
+    end
+
+    context 'when admin connection is false' do
+      let(:tenant) { double('Tenant', id: 123) }
+
+      before do
+        allow(PgRls).to receive(:admin_connection?).and_return(false)
+        allow(PgRls::Tenant).to receive(:fetch).and_return(tenant)
+      end
+
+      it 'sets pg_rls attribute with tenant id for the job' do
+        Sidekiq::Testing.inline! do
+          DummyTenantWorker.perform_async
+        end
+      end
+    end
+
+    context 'when the job fails' do
+      let(:tenant) { double('Tenant', id: 123) }
+
+      before do
+        allow(PgRls).to receive(:admin_connection?).and_return(false)
+        allow(PgRls::Tenant).to receive(:fetch).and_return(tenant)
+      end
+
+      it 'raises the error triggered by the job (not other raised in the middleware)' do
+        Sidekiq::Testing.inline! do
+          expect { DummyFailingWorker.perform_async }.to raise_error('Failed job')
+        end
+      end
+    end
+  end
+end

--- a/spec/pg_rls_spec.rb
+++ b/spec/pg_rls_spec.rb
@@ -6,6 +6,6 @@ RSpec.describe PgRls do
   end
 
   it 'does something useful' do
-    expect(require_relative('lib/PgRls/version')).to be(true)
+    expect(require_relative('../lib/pg_rls/version')).to be(false)
   end
 end


### PR DESCRIPTION
Tries to solve #15 and #16.

As an additional suggestion, part of the initializer should be moved even before environment.rb, because, on the migrations, the password is taken from the mattr accessor of the gem instead of the initializer.

My solution was:

1) Divide the initializer.

```ruby
# config/initializers/pg_rls_database.rb
require 'pg_rls'

PgRls.setup do |config|
  ActiveRecord::ConnectionAdapters::AbstractAdapter.include PgRls::Schema::Statements

  config.class_name = :my_main_model
  config.table_name = :my_main_model
  config.search_methods = %i[id tenant_id]
  config.password = ENV.fetch('POSTGRES_PASSWORD', 'some_default_password')
end

```
(the following part should be loaded after Redis initialization)

```ruby
#config/initializers/pg_rls_session.rb
PgRls.setup do |config|
  config.session_store_server = Rails.application.config_for(:redis).session
  config.session_key_prefix = "_hub_session_#{Rails.env}"
end
```

2) 
Requiring the db initializer on application.rb:
```ruby
require_relative '../config/initializers/pg_rls_database'
```

3) Removing the initialization on environment.rb because it is no longer necessary.