### PR TITLE
Fixing  PgRls::Admin::ActiveRecord::Migrator to not set as_db_admin to true in development environments and set as_db_admin in false after run execute_query_or_block

### DIFF
--- a/lib/pg_rls.rb
+++ b/lib/pg_rls.rb
@@ -146,6 +146,8 @@ module PgRls
       else
         execute(query)
       end
+    ensure
+      self.as_db_admin = false
     end
 
     def reset_connection_if_needed(current_tenant, reset_rls_connection)

--- a/lib/pg_rls/database/admin_statements.rb
+++ b/lib/pg_rls/database/admin_statements.rb
@@ -5,7 +5,7 @@ module PgRls
     module ActiveRecord
       module Migrator
         def initialize(*args)
-          PgRls.instance_variable_set(:@as_db_admin, true)
+          PgRls.instance_variable_set(:@as_db_admin, true) unless Rails.const_defined?('Server')
           super
         end
       end


### PR DESCRIPTION
- Fixed PgRls::Admin::ActiveRecord::Migrator to not set as_db_admin to true in development environments
- Set as_db_admin in false after run execute_query_or_block